### PR TITLE
To compatible with turbolinks

### DIFF
--- a/src/notify.coffee
+++ b/src/notify.coffee
@@ -216,6 +216,10 @@ createElem = (tag) ->
 # references to global anchor positions
 globalAnchors = {}
 
+# method to clear globalANchors
+clearAnchors = ->
+  globalAnchors = {}
+
 #gets first on n radios, and gets the fancy stylised input for hidden inputs
 getAnchorElement = (element) ->
   #choose the first of n radios
@@ -551,7 +555,7 @@ $.fn[pluginName] = (data, options) ->
   @
 
 #extra methods
-$.extend $[pluginName], { defaults, addStyle, pluginOptions, getStyle, insertCSS }
+$.extend $[pluginName], { defaults, addStyle, pluginOptions, getStyle, insertCSS, clearAnchors }
 
 #when ready
 $ ->


### PR DESCRIPTION
When [Turbolinks](https://github.com/rails/turbolinks) is enabled and when a link is clicked, `Turbolinks` will fetch new page and replace current page's body content with new page's one. This will cause `<div class='notifyjs_corner'>` disappeared from DOM, and notify message will never be showed any more.

This patch will add a method to clear globalAnchors to be compatible with javascript library like `Turbolinks`.
With `Turbolinks` it may be invoked like

```
$(document).on("page:update", function(){
  $.notify.clearAnchors();
});

```