### PR TITLE
Fixed anchors cache

### DIFF
--- a/dist/notify.js
+++ b/dist/notify.js
@@ -337,7 +337,7 @@
 		var align = positions[pAlign];
 		var key = pMain + "|" + pAlign;
 		var anchor = globalAnchors[key];
-		if (!anchor) {
+		if (!anchor || !document.contains(anchor[0])) {
 			anchor = globalAnchors[key] = createElem("div");
 			var css = {};
 			css[main] = 0;


### PR DESCRIPTION
Fixed anchors cache for compatibility with Turbolinks.
"Anchor" element must not be used if it occasionally is out of DOM.