### PR TITLE
jquery peerDep changes to 1.x version minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "jshint ./dist/*.js"
   },
   "peerDependencies": {
-    "jquery": "^2.1.4"
+    "jquery": ">=1.11.0"
   },
   "devDependencies": {
     "jshint": "^2.8.0"


### PR DESCRIPTION
It prevents errors with npm install when using jquery 1.x version in project.