### PR TITLE
adding git repo to package.json so the repo is linked from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "author": {
     "name": "Jaime Pillora"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/notifyjs/notifyjs.git"
+  },
   "contributors": [
     {
       "name": "Evan Carroll",


### PR DESCRIPTION
please version and run `npm publish` with this PR so we can get the github repo linked on npm. I'm running some automation against NPM to get github repos for packages, but this project doesn't show one because of the missing repo entry in package.json.

Thanks!
