### PR TITLE
Return notification instance so we can trigger notify-hide on it

### DIFF
--- a/dist/notify.js
+++ b/dist/notify.js
@@ -534,16 +534,16 @@
 		this.wrapper.data(pluginClassName, null);
 		this.wrapper.remove();
 	};
-
+	
 	$[pluginName] = function(elem, data, options) {
 		if ((elem && elem.nodeName) || elem.jquery) {
 			$(elem)[pluginName](data, options);
+			return elem;
 		} else {
 			options = data;
 			data = elem;
-			new Notification(null, data, options);
+			return new Notification(null, data, options);
 		}
-		return elem;
 	};
 
 	$.fn[pluginName] = function(data, options) {


### PR DESCRIPTION

Example: var loading = $.notify("Perfoming Update", {  clickToHide: true });

 $(element).on("update_finished",function() {  loading.trigger("notify-hide"); });