### PR TITLE
call 'contains method' from 'document.body' (for ie)

### DIFF
--- a/dist/notify.js
+++ b/dist/notify.js
@@ -346,7 +346,7 @@
 		var align = positions[pAlign];
 		var key = pMain + "|" + pAlign;
 		var anchor = globalAnchors[key];
-		if (!anchor || !document.contains(anchor[0])) {
+		if (!anchor || !document.body.contains(anchor[0])) {
 			anchor = globalAnchors[key] = createElem("div");
 			var css = {};
 			css[main] = 0;


### PR DESCRIPTION
IE - document.contains doesn't exist. (https://github.com/skatejs/skatejs/issues/153)