### PR TITLE
Fix issue with IE11

### DIFF
--- a/dist/notify.js
+++ b/dist/notify.js
@@ -346,7 +346,7 @@
 		var align = positions[pAlign];
 		var key = pMain + "|" + pAlign;
 		var anchor = globalAnchors[key];
-		if (!anchor || !document.contains(anchor[0])) {
+		if (!anchor || !$.contains(document.body,anchor[0])) {
 			anchor = globalAnchors[key] = createElem("div");
 			var css = {};
 			css[main] = 0;


### PR DESCRIPTION
document.contains not exist in IE11 replace it with $.contains(document.body,anchor[0])